### PR TITLE
Add missing dependencies needed before training

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ uv sync
 MFA (micromamba)
 
 ```bash
-micromamba create -n mfa -c conda-forge python=3.12 montreal-forced-aligner
+micromamba create -n mfa -c conda-forge python=3.12 montreal-forced-aligner 
 micromamba activate mfa
 
 mfa model download acoustic english_us_arpa
 mfa model download dictionary english_us_arpa
 mfa model download g2p english_us_arpa
+```
+
+Other dependencies needed before training:
+```bash
+pip install torch
+micromamba install -c pytorch torchaudio numpy scikit-learn tqdm tensorboard matplotlib
 ```
 
 Dataset Download is now integrated in the training script.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ uv sync
 MFA (micromamba)
 
 ```bash
-micromamba create -n mfa -c conda-forge python=3.12 montreal-forced-aligner 
+micromamba create -n mfa -c conda-forge python=3.12 montreal-forced-aligner
 micromamba activate mfa
 
 mfa model download acoustic english_us_arpa


### PR DESCRIPTION
When I tried to run it fresh it was saying I was missing a lot before it would let me run the training python..

If I find more that are needed I will update, or create new pull if more stuff is found that needed to be installed.